### PR TITLE
Fixed Lists

### DIFF
--- a/BeatFollower/UI/EndLevelViewController.cs
+++ b/BeatFollower/UI/EndLevelViewController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BeatFollower.Models;
@@ -6,16 +6,19 @@ using BeatFollower.Services;
 using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.ViewControllers;
+using UnityEngine;
 
 namespace BeatFollower.UI
 {
-    [HotReload(@"C:\working\BeatFollowerPlugin\BeatFollower\UI\Views\EndLevel.bsml")]
+    [HotReload(RelativePathToLayout = @"Views\\EndLevel.bsml")]
     [ViewDefinition("BeatFollower.UI.Views.EndLevel.bsml")]
     public class EndLevelViewController : BSMLAutomaticViewController
     {
+		[UIComponent("customlist-list")]
+		public RectTransform customListsListRect;
+
         [UIComponent("customlist-list")]
         public CustomCellListTableData customListsList;
-
 
         [UIValue("customlists")]
         public List<object> customListUi = new List<object>();
@@ -29,7 +32,11 @@ namespace BeatFollower.UI
                 CustomListService.GetCustomLists(SetCustomList);
             }
 
-        } 
+        }
+
+		[UIComponent("customlist-list2")]
+		public RectTransform customListList2Rect;
+
         [UIComponent("customlist-list2")]
         public CustomCellListTableData customListsList2;
 
@@ -93,6 +100,10 @@ namespace BeatFollower.UI
             {
                 Logger.log.Error(e);
             }
+
+			// Manually set the list container to the correct size
+			customListsListRect.sizeDelta = new Vector2(customListUi.Count * customListsList.cellSize, customListsListRect.sizeDelta.y);
+			customListList2Rect.sizeDelta = new Vector2(customListUi2.Count * customListsList2.cellSize, customListList2Rect.sizeDelta.y);
 
             customListsList.tableView.ReloadData();
             customListsList2.tableView.ReloadData();

--- a/BeatFollower/UI/Views/EndLevel.bsml
+++ b/BeatFollower/UI/Views/EndLevel.bsml
@@ -1,4 +1,4 @@
-﻿<bg>
+<bg>
   <vertical vertical-fit='Unconstrained'>
       <horizontal pad-bottom='4' horizontal-fit='PreferredSize'>
         <text text='BeatFollower Add To' align='Center' font-size='4'/>


### PR DESCRIPTION
The list containers were being set to 150 by default. Parsing originally happens before the values for the list, are set, so the list widths aren't properly set. Upon hot-reloading, all the UI gets created but the host remains, and now has the values (buttons), so it would then calculate the proper list width.